### PR TITLE
Use new header for canbus driver

### DIFF
--- a/src/tools/MainTest.cpp
+++ b/src/tools/MainTest.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include "canbus.hh"
+#include <canbus/Driver.hpp>
 #include <iomanip>
 #include <map>
 #include <boost/lexical_cast.hpp>


### PR DESCRIPTION
Building the canbus driver without this change failed on three fresh rock installations (master flavor with C++11) on Ubuntu 16.04, because **_"canbus.hh"_ cannot be found**.
Can you please merge this tiny commit or is there a reason to keep using the moved _"canbus.hh"_, which only imports _<canbus/Driver.hpp>_?