### PR TITLE
specify how RTR, EFF and Error flags should be specified in can_id

### DIFF
--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -24,23 +24,51 @@ namespace canbus
         NET_GATEWAY,
         EASY_SYNC
     };
-    
+
+    /** Values used to encode specific flags in the can_id field of Message
+     */
+    enum MessageFlags {
+        FLAG_ERROR = (1 << 29),
+        FLAG_REMOTE_TRANSMISSION_REQUEST = (1 << 30),
+        FLAG_EXTENDED_FRAME = (1 << 31)
+    };
+
+    /** A decoded CAN frame */
     struct Message
     {
         base::Time time;
         base::Time can_time;
 
+        /** CAN ID and special flags
+         *
+         * When sending, it follows Linux' format for the can_id field, that is:
+         * - ID: bits 0-11 for standard frame, or 0-28 for extended frame
+         * - Error: bit 29
+         * - RTR bit: bit 30
+         * - Frame format: bit 30, 0 for standard, 1 for extended
+         *
+         * On reception, the drivers should report an error through the API's
+         * error mechanism on error. They return a RTR with the flag set in the
+         * ID. and do not report anything specific for an extended frame.
+         *
+         * Not all drivers support these flags. The only one that is currently
+         * guaranteed to is the Socket-CAN driver.
+         */
         uint32_t can_id;
+
+        /** Actual data in the frame */
         uint8_t  data[8];
+
+        /** How many valid bytes there is in data */
         uint8_t  size;
     };
-    
+
     struct Status
     {
       base::Time time;
       uint8_t error;
     };
-      
+
 }
 
 #endif


### PR DESCRIPTION
This follows how Socket-CAN behaves, which has the advantage to be
compatible with the current Message layout (anything else would
require to change the type)