### PR TITLE
fix test suite and define Message::Zeroed()

### DIFF
--- a/src/DriverEasySYNC.cpp
+++ b/src/DriverEasySYNC.cpp
@@ -62,7 +62,7 @@ bool DriverEasySYNC::open(string const& path)
 
     // Force-close. Will fail if the device is already closed
     try { processSimpleCommand("C\r", 2); }
-    catch(FailedCommand) { }
+    catch(FailedCommand&) { }
     processSimpleCommand("E\r", 2);
     if (useBoardTimestamps())
         processSimpleCommand("Z1\r", 3);
@@ -134,7 +134,7 @@ static void commandWithRetries(T lambda, int retries, int timeout) {
         try {
             lambda((deadline - base::Time::now()).toMilliseconds());
             break;
-        } catch (canbus::DriverEasySYNC::FailedCommand) {
+        } catch (canbus::DriverEasySYNC::FailedCommand&) {
             if (--retries <= 0)
                 throw;
         }
@@ -150,7 +150,7 @@ int DriverEasySYNC::getPendingMessagesCount()
             mQueue.insert(mQueue.begin(), msg);
         }
     }
-    catch(iodrivers_base::TimeoutError) {}
+    catch(iodrivers_base::TimeoutError&) {}
     return mQueue.size();
 }
 

--- a/src/Message.hpp
+++ b/src/Message.hpp
@@ -61,6 +61,16 @@ namespace canbus
 
         /** How many valid bytes there is in data */
         uint8_t  size;
+
+        static Message Zeroed() {
+            Message result;
+            result.can_id = 0;
+            for (int i = 0; i < 8; ++i) {
+                result.data[i] = 0;
+            }
+            result.size = 0;
+            return result;
+        }
     };
 
     struct Status

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,3 @@
 rock_gtest(test_suite suite.cpp
-    test_DriverEasySYNC.cpp
+    test_DriverEasySYNC.cpp test_Message.cpp
     DEPS canbus)

--- a/test/test_Message.cpp
+++ b/test/test_Message.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include <canbus/Message.hpp>
+
+using namespace std;
+using namespace canbus;
+
+struct MessageTest : public ::testing::Test {
+};
+
+TEST_F(MessageTest, it_produces_a_zeroed_message)
+{
+    auto msg = Message::Zeroed();
+    ASSERT_TRUE(msg.time.isNull());
+    ASSERT_TRUE(msg.can_time.isNull());
+    ASSERT_EQ(0, msg.can_id);
+    ASSERT_EQ(0, msg.size);
+    for (int i = 0; i < 8; ++i) {
+        ASSERT_EQ(0, msg.data[i]);
+    }
+}


### PR DESCRIPTION
The test suite was broken at the point where it was merged in the package. Fix it to match
the changes that broke it (I don't have access to an EasySYNC adapter anymore)

For Message::Zeroed(), the commonly used "method" of using memset is not valid
under C++11 and later (generates warnings)

